### PR TITLE
Support native address in Follow Up Boss

### DIFF
--- a/real_intent/deliver/followupboss/ai_fields.py
+++ b/real_intent/deliver/followupboss/ai_fields.py
@@ -209,7 +209,7 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
         # Prepare the PII data
         filtered_pii_data: dict[str, Any] = {
             key: val for key, val in md5_with_pii.pii.model_dump().items() 
-            if key not in {"first_name", "last_name", "emails", "mobile_phones"}
+            if key not in {"first_name", "last_name", "emails", "mobile_phones", "addresses"}
         }
         filtered_pii_data_str: str = json.dumps(filtered_pii_data, indent=4)
 

--- a/real_intent/deliver/followupboss/vanilla.py
+++ b/real_intent/deliver/followupboss/vanilla.py
@@ -148,6 +148,14 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
             person_data["emails"] = [{"value": email} for email in md5_with_pii.pii.emails]
         if md5_with_pii.pii.mobile_phones:
             person_data["phones"] = [{"value": phone.phone} for phone in md5_with_pii.pii.mobile_phones]
+        if md5_with_pii.pii.address and md5_with_pii.pii.city and md5_with_pii.pii.state and md5_with_pii.pii.zip_code:
+            person_data["addresses"] = [{
+                "type": "home",
+                "street": md5_with_pii.pii.address,
+                "city": md5_with_pii.pii.city,
+                "state": md5_with_pii.pii.state,
+                "code": md5_with_pii.pii.zip_code
+            }]
 
         # Prepare sentences
         sentences: list[str] = []


### PR DESCRIPTION
Follow Up Boss has a native field for a lead's address. Parse PII into event data if enough fields are present to send into FUB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality to include address information in event data preparation.
- **Bug Fixes**
	- Improved privacy measures by excluding address data from sensitive information handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->