### PR TITLE
Agent notes in kvCORE integration

### DIFF
--- a/tests/test_kvcore.py
+++ b/tests/test_kvcore.py
@@ -16,3 +16,4 @@ def test_kvcore_email_body(sample_pii_md5s) -> None:
     assert "Last Name" in email_body, "Last Name should be in email body"
     assert "Email" in email_body, "Email should be in email body"
     assert "Phone" in email_body, "Phone should be in email body"
+    assert "Agent Notes" in email_body, "Agent Notes should be in email body"


### PR DESCRIPTION
Closes #94.

Populate kvCORE user's `Agent Notes` (for each lead) with stringified key values of curated PII attributes.

Curated PII attrs are hardcoded. Uses new `._agent_notes` method to allow the entire class to be subclasses for eventual per-lead insights.

Eventually, call `super()._agent_notes(...)` before appending AI insight to the end, similar to the subclassing behavior from the original FUB integration to the AI one.