### PR TITLE
Proper handling of the FUB rate limit

### DIFF
--- a/real_intent/deliver/followupboss/ai_fields.py
+++ b/real_intent/deliver/followupboss/ai_fields.py
@@ -7,7 +7,7 @@ from typing import Literal, Any
 import time
 
 from real_intent.schemas import MD5WithPII
-from real_intent.deliver.followupboss.vanilla import FollowUpBossDeliverer, EventType, InvalidAPICredentialsError
+from real_intent.deliver.followupboss.vanilla import FollowUpBossDeliverer, EventType, InvalidAPICredentialsError, fub_rate_limited
 from real_intent.deliver.followupboss.ai_prompt import SYSTEM_PROMPT
 from real_intent.internal_logging import log, log_span
 
@@ -157,6 +157,7 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
             log("error", f"Error in AI field mapping delivery for lead {md5_with_pii.md5}: {str(e)}. Falling back to standard delivery.")
             return super()._deliver_single_lead(md5_with_pii)
 
+    @fub_rate_limited
     def _get_custom_fields(self) -> list[CustomField]:
         """
         Get the custom fields from the user's Follow Up Boss account.
@@ -180,6 +181,7 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
             
             return custom_fields
 
+    @fub_rate_limited
     def _create_custom_field(self, custom_field: CustomFieldCreation) -> CustomField:
         """
         Create a custom field in the user's Follow Up Boss account.

--- a/real_intent/deliver/followupboss/vanilla.py
+++ b/real_intent/deliver/followupboss/vanilla.py
@@ -146,7 +146,7 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
         # Log if any of the leads are on the DNC list
         self._warn_dnc(pii_md5s)
 
-        with ThreadPoolExecutor(max_workers=5) as executor:
+        with ThreadPoolExecutor(max_workers=3) as executor:
             return list(executor.map(self._deliver_single_lead, pii_md5s))
 
     def _deliver_single_lead(self, md5_with_pii: MD5WithPII) -> dict:


### PR DESCRIPTION
Creation of `@fub_rate_limited` decorator. Applied to any FUB methods interacting with the API. Max retries hardcoded to 5, but intelligently determines the amount of time to wait according to received headers. Also, drop FUB concurrency from 5 to 3.