### PR TITLE
Automatic Do Not Sell (DNS) validation

### DIFF
--- a/real_intent/validate/dns.py
+++ b/real_intent/validate/dns.py
@@ -1,0 +1,68 @@
+"""Validation for the Do Not Sell list."""
+import requests
+
+from real_intent.validate.base import BaseValidator
+from real_intent.schemas import MD5WithPII
+
+
+class FilloutDNSValidator(BaseValidator):
+    """Removes leads with an email on the Do Not Sell (DNS) blacklist."""
+
+    def __init__(self, fillout_api_key: str, fillout_form_id: str, question_id: str) -> None:
+        self.fillout_api_key: str = fillout_api_key
+        self.fillout_form_id: str = fillout_form_id
+        self.question_id: str = question_id
+
+    @property
+    def fillout_api_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.fillout_api_key}",
+        }
+
+    def _get_submissions(self) -> list[dict]:
+        """Pull all submissions from the Fillout form."""
+        offset: int = 0
+        submissions: list[dict] = []
+
+        while True:
+            submissions_res = requests.get(
+                f"https://api.fillout.com/v1/api/forms/{self.fillout_form_id}/submissions", 
+                headers=self.fillout_api_headers,
+                params={"limit": 150, "offset": offset}
+            )
+            submissions_res.raise_for_status()
+            submissions_res_json = submissions_res.json()
+
+            submissions += submissions_res_json["responses"]
+
+            if len(submissions_res_json["responses"]) < 150:
+                break
+
+            offset += 150
+
+        return submissions
+
+    def _email_from_submission(self, submission: dict) -> str:
+        """Extract the requested email from a Fillout submission."""
+        question_answers: list[dict] = submission["questions"]
+
+        if not question_answers:
+            raise ValueError("No questions found in submission.")
+
+        if not any(q["id"] == self.question_id for q in question_answers):
+            raise ValueError("No email question found in submission.")
+
+        email_answer: dict = next(q for q in question_answers if q["id"] == self.question_id)
+        return str(email_answer["value"])
+
+    def all_emails(self) -> list[str]:
+        """Get all emails from Fillout submissions."""
+        return [self._email_from_submission(s) for s in self._get_submissions()]
+
+    def _validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
+        """Remove leads with an email on the Do Not Sell (DNS) blacklist."""
+        return [
+            md5 for md5 in md5s if all(
+                email not in self.all_emails() for email in md5.pii.emails
+            )
+        ]

--- a/tests/test_dns_validator.py
+++ b/tests/test_dns_validator.py
@@ -1,0 +1,93 @@
+"""Test the Fillout DNS validator."""
+import pytest
+import os
+from dotenv import load_dotenv
+
+from real_intent.validate.dns import FilloutDNSValidator
+from real_intent.schemas import MD5WithPII
+
+# Load environment variables from .env file
+load_dotenv()
+
+@pytest.fixture
+def fillout_dns_validator():
+    return FilloutDNSValidator(
+        os.getenv('FILLOUT_API_KEY'),
+        os.getenv('FILLOUT_DNS_FORM_ID'),
+        os.getenv('FILLOUT_DNS_QUESTION_ID')
+    )
+
+@pytest.fixture
+def dns_test_md5s(sample_pii_md5s):
+    # Create a copy of the sample_pii_md5s and modify it
+    test_md5s = sample_pii_md5s.copy()
+    
+    # Add a new MD5WithPII object with the email we want to test
+    new_pii = test_md5s[0].pii.model_copy(deep=True)
+    new_pii.emails.append("preritdas@gmail.com")
+    test_md5s.append(MD5WithPII(
+        md5="0123456789abcdef",
+        sentences=["another test sentence"],
+        pii=new_pii
+    ))
+    
+    return test_md5s
+
+@pytest.mark.skipif(
+    not os.getenv("FILLOUT_API_KEY")
+    or not os.getenv("FILLOUT_DNS_FORM_ID")
+    or not os.getenv("FILLOUT_DNS_QUESTION_ID"),
+    reason="Fillout API credentials not found",
+)
+def test_fillout_dns_validator_initialization(fillout_dns_validator):
+    assert fillout_dns_validator.fillout_api_key == os.getenv('FILLOUT_API_KEY')
+    assert fillout_dns_validator.fillout_form_id == os.getenv('FILLOUT_DNS_FORM_ID')
+    assert fillout_dns_validator.question_id == os.getenv('FILLOUT_DNS_QUESTION_ID')
+
+@pytest.mark.skipif(
+    not os.getenv("FILLOUT_API_KEY")
+    or not os.getenv("FILLOUT_DNS_FORM_ID")
+    or not os.getenv("FILLOUT_DNS_QUESTION_ID"),
+    reason="Fillout API credentials not found",
+)
+def test_fillout_api_headers(fillout_dns_validator):
+    expected_headers = {
+        "Authorization": f"Bearer {os.getenv('FILLOUT_API_KEY')}"
+    }
+    assert fillout_dns_validator.fillout_api_headers == expected_headers
+
+@pytest.mark.skipif(
+    not os.getenv("FILLOUT_API_KEY")
+    or not os.getenv("FILLOUT_DNS_FORM_ID")
+    or not os.getenv("FILLOUT_DNS_QUESTION_ID"),
+    reason="Fillout API credentials not found",
+)
+def test_get_submissions(fillout_dns_validator):
+    submissions = fillout_dns_validator._get_submissions()
+    assert isinstance(submissions, list)
+    assert len(submissions) > 0
+
+@pytest.mark.skipif(
+    not os.getenv("FILLOUT_API_KEY")
+    or not os.getenv("FILLOUT_DNS_FORM_ID")
+    or not os.getenv("FILLOUT_DNS_QUESTION_ID"),
+    reason="Fillout API credentials not found",
+)
+def test_all_emails(fillout_dns_validator):
+    emails = fillout_dns_validator.all_emails()
+    assert isinstance(emails, list)
+    assert len(emails) > 0
+    assert all(isinstance(email, str) for email in emails)
+
+@pytest.mark.skipif(
+    not os.getenv("FILLOUT_API_KEY")
+    or not os.getenv("FILLOUT_DNS_FORM_ID")
+    or not os.getenv("FILLOUT_DNS_QUESTION_ID"),
+    reason="Fillout API credentials not found",
+)
+def test_validate(fillout_dns_validator, dns_test_md5s):
+    result = fillout_dns_validator.validate(dns_test_md5s)
+    assert isinstance(result, list)
+    assert len(result) == 1  # Expecting 1 out of 2 to pass validation
+    assert all(md5.pii.emails[0] != "preritdas@gmail.com" for md5 in result)
+    assert result[0].md5 == dns_test_md5s[0].md5


### PR DESCRIPTION
Introduces the `FilloutDNSValidator`, automatically pulling do not sell submissions and validating them out of processor `list[MD5WithPII` results. 

Integration tests work and depend on the Fillout API key, form ID, and question ID pointing to the email. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `FilloutDNSValidator` class for validating email submissions against a Do Not Sell blacklist.
	- Added functionality to retrieve submissions and extract email addresses for validation.

- **Tests**
	- Created a test suite for the `FilloutDNSValidator` class, ensuring proper functionality and validation logic through unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->