### PR TITLE
Occupation-based validation

### DIFF
--- a/real_intent/validate/pii.py
+++ b/real_intent/validate/pii.py
@@ -53,6 +53,14 @@ class RemoveOccupationsValidator(BaseValidator):
         ]
 
 
+class NoRealEstateAgentValidator(RemoveOccupationsValidator):
+    """Remove leads that are real estate agents."""
+
+    def __init__(self) -> None:
+        """Initialize with the filtered occupation."""
+        super().__init__("Real Estate/Realtor")
+
+
 class MidIncomeValidator(BaseValidator):
     """Remove leads below $30k income."""
 

--- a/real_intent/validate/pii.py
+++ b/real_intent/validate/pii.py
@@ -39,6 +39,20 @@ class AgeValidator(BaseValidator):
         return [md5 for md5 in md5s if is_valid(md5)]
 
 
+class RemoveOccupationsValidator(BaseValidator):
+    """Remove leads with specified occupations."""
+
+    def __init__(self, *occupations: str) -> None:
+        """Initialize with the filtered occupations."""
+        self.occupations: set[str] = set(occupations)
+
+    def _validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
+        """Only return leads whose occupation does not exist in the initialized list of occupations."""
+        return [
+            md5 for md5 in md5s if md5.pii.occupation not in self.occupations
+        ]
+
+
 class MidIncomeValidator(BaseValidator):
     """Remove leads below $30k income."""
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from real_intent.schemas import Gender, MD5WithPII, PII, MobilePhone
 from real_intent.validate.email import EmailValidator, HasEmailValidator
 from real_intent.validate.phone import PhoneValidator, DNCValidator, DNCPhoneRemover
+from real_intent.validate.pii import RemoveOccupationsValidator
 
 
 # Load environment variables from .env file
@@ -258,3 +259,24 @@ def test_sentence_count() -> None:
     md5_empty = create_md5_with_pii("789", [], [], sentences=[])
     assert md5_empty.total_sentence_count == 0
     assert md5_empty.unique_sentence_count == 0
+
+
+def test_remove_occupations_validator() -> None:
+    piis = [
+        create_md5_with_pii("123", [], ["1234567890"], sentences=["sentence1"]),
+        create_md5_with_pii("456", [], ["9876543210"], sentences=["sentence2"]),
+        create_md5_with_pii("789", [], ["5556667777"], sentences=["sentence3"]),
+        create_md5_with_pii("101", [], ["9998887777"], sentences=["sentence4"])
+    ]
+
+    # Set occupations
+    piis[0].pii.occupation = "Bad Occupation"
+
+    # Initialize validator
+    validator = RemoveOccupationsValidator("Bad Occupation")
+
+    # Validate
+    result = validator.validate(piis)
+
+    # Check results
+    assert len(result) == 3


### PR DESCRIPTION
# Occupation-based validation

## Changes

Introduces a new validator class `RemoveOccupationsValidator` and updates related components to enhance lead filtering capabilities based on occupations.

### `real_intent/validate/pii.py`

- Added `RemoveOccupationsValidator` class:
  - Allows filtering leads based on a set of specified occupations
  - Implements `_validate` method to remove leads with matching occupations
- Modified `NoRealEstateAgentValidator`:
  - Inherits from `RemoveOccupationsValidator`
  - Specifically filters out "Real Estate/Realtor" occupation

### `tests/test_validation.py`

- Imported `RemoveOccupationsValidator`
- Added `test_remove_occupations_validator()` function to test the new validator

## Purpose

The `RemoveOccupationsValidator` provides a flexible way to filter leads based on their occupations. This can be useful for:
- Targeting specific audience segments
- Excluding certain professions from lead lists
- Customizing lead filtering based on client requirements

The `NoRealEstateAgentValidator` now leverages this new class, demonstrating its practical application and maintaining existing functionality.

## Testing

A new test case `test_remove_occupations_validator()` has been added to ensure the correct functionality of the `RemoveOccupationsValidator`. This test creates a set of sample leads, applies the validator, and checks that leads with specified occupations are removed correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new validators to filter leads based on specified occupations, enhancing PII validation capabilities.
  
- **Tests**
	- Added a new test function to validate the functionality of the `RemoveOccupationsValidator`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->