### PR TITLE
Physical address in kvCORE agent notes

### DIFF
--- a/real_intent/deliver/kvcore/__init__.py
+++ b/real_intent/deliver/kvcore/__init__.py
@@ -85,7 +85,29 @@ class KVCoreDeliverer(BaseOutputDeliverer):
     @staticmethod
     def _address_str(pii_md5: MD5WithPII) -> str:
         """Generate a string representation of the address."""
-        
+        address_parts = []
+
+        # Add street address if available
+        if pii_md5.pii.address:
+            address_parts.append(pii_md5.pii.address)
+
+        # Add city if available
+        if pii_md5.pii.city:
+            address_parts.append(pii_md5.pii.city)
+
+        # Add state if available
+        if pii_md5.pii.state:
+            address_parts.append(pii_md5.pii.state)
+
+        # Add zip code and zip4 if available
+        if pii_md5.pii.zip_code:
+            zip_str = pii_md5.pii.zip_code
+            if pii_md5.pii.zip4:
+                zip_str += f"-{pii_md5.pii.zip4}"
+            address_parts.append(zip_str)
+
+        # Join all parts with appropriate separators
+        return ", ".join(address_parts)
 
     def _agent_notes(self, pii_md5: MD5WithPII) -> str:
         """Generate custom agent notes for a single lead."""

--- a/real_intent/deliver/kvcore/__init__.py
+++ b/real_intent/deliver/kvcore/__init__.py
@@ -88,22 +88,24 @@ class KVCoreDeliverer(BaseOutputDeliverer):
         address_parts: list[str] = []
 
         # Add street address if available
-        if pii_md5.pii.address:
-            address_parts.append(pii_md5.pii.address)
+        if addr := pii_md5.pii.address.strip():
+            address_parts.append(addr)
 
         # Add city if available
-        if pii_md5.pii.city:
-            address_parts.append(pii_md5.pii.city)
+        if city := pii_md5.pii.city.strip():
+            address_parts.append(city)
 
         # Add state if available
-        if pii_md5.pii.state:
-            address_parts.append(pii_md5.pii.state)
+        if state := pii_md5.pii.state.strip():
+            address_parts.append(state)
 
         # Add zip code and zip4 if available
-        if pii_md5.pii.zip_code:
-            zip_str: str = pii_md5.pii.zip_code
-            if pii_md5.pii.zip4:
-                zip_str += f"-{pii_md5.pii.zip4}"
+        if zip_code := pii_md5.pii.zip_code.strip():
+            zip_str: str = zip_code
+
+            if zip4 := pii_md5.pii.zip4.strip():
+                zip_str += f"-{zip4}"
+
             address_parts.append(zip_str)
 
         # Join all parts with appropriate separators

--- a/real_intent/deliver/kvcore/__init__.py
+++ b/real_intent/deliver/kvcore/__init__.py
@@ -122,6 +122,9 @@ class KVCoreDeliverer(BaseOutputDeliverer):
         if (insight := self.per_lead_insights.get(pii_md5.md5)):
             attrs["Insight"] = insight
 
+        if (address := self._address_str(pii_md5)):
+            attrs["Address"] = address
+
         return "\n".join([f"{k}: {v}" for k, v in attrs.items()])
 
     def _email_body(self, pii_md5: MD5WithPII) -> str:

--- a/real_intent/deliver/kvcore/__init__.py
+++ b/real_intent/deliver/kvcore/__init__.py
@@ -82,6 +82,11 @@ class KVCoreDeliverer(BaseOutputDeliverer):
 
         return True
 
+    @staticmethod
+    def _address_str(pii_md5: MD5WithPII) -> str:
+        """Generate a string representation of the address."""
+        
+
     def _agent_notes(self, pii_md5: MD5WithPII) -> str:
         """Generate custom agent notes for a single lead."""
         attrs: dict[str | Any] = {}

--- a/real_intent/deliver/kvcore/__init__.py
+++ b/real_intent/deliver/kvcore/__init__.py
@@ -85,7 +85,7 @@ class KVCoreDeliverer(BaseOutputDeliverer):
     @staticmethod
     def _address_str(pii_md5: MD5WithPII) -> str:
         """Generate a string representation of the address."""
-        address_parts = []
+        address_parts: list[str] = []
 
         # Add street address if available
         if pii_md5.pii.address:
@@ -101,7 +101,7 @@ class KVCoreDeliverer(BaseOutputDeliverer):
 
         # Add zip code and zip4 if available
         if pii_md5.pii.zip_code:
-            zip_str = pii_md5.pii.zip_code
+            zip_str: str = pii_md5.pii.zip_code
             if pii_md5.pii.zip4:
                 zip_str += f"-{pii_md5.pii.zip4}"
             address_parts.append(zip_str)

--- a/tests/test_kvcore.py
+++ b/tests/test_kvcore.py
@@ -17,3 +17,14 @@ def test_kvcore_email_body(sample_pii_md5s) -> None:
     assert "Email" in email_body, "Email should be in email body"
     assert "Phone" in email_body, "Phone should be in email body"
     assert "Agent Notes" in email_body, "Agent Notes should be in email body"
+    
+    # Verify address components appear in agent notes
+    pii = sample_pii_md5s[0].pii
+    if pii.address.strip():
+        assert pii.address.strip() in email_body, "Street address should be in agent notes"
+    if pii.city.strip():
+        assert pii.city.strip() in email_body, "City should be in agent notes"
+    if pii.state.strip():
+        assert pii.state.strip() in email_body, "State should be in agent notes"
+    if pii.zip_code.strip():
+        assert pii.zip_code.strip() in email_body, "Zip code should be in agent notes"


### PR DESCRIPTION
Not much else to say.

With all components present it would format like:
"123 Main St, Springfield, IL, 12345-6789"

And with some components missing it adapts appropriately, e.g.:
"Springfield, IL, 12345"