### PR TITLE
Automatic single retry on FUB note add failure

### DIFF
--- a/real_intent/deliver/followupboss/vanilla.py
+++ b/real_intent/deliver/followupboss/vanilla.py
@@ -298,6 +298,7 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
             response.raise_for_status()
 
         if response.ok:
+            log("trace", f"Successfully added note to person {person_id}")
             return True
 
         # Retry on contact not found error

--- a/real_intent/deliver/followupboss/vanilla.py
+++ b/real_intent/deliver/followupboss/vanilla.py
@@ -268,7 +268,7 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
         return response.json()
 
     @fub_rate_limited
-    def _add_note(self, person_id: int, body: str, subject: str = "") -> bool:
+    def _add_note(self, person_id: int, body: str, subject: str = "", retry: bool = True) -> bool:
         """
         Add a note to a person in Follow Up Boss.
 
@@ -276,6 +276,7 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
             person_id (str): The ID of the person to add the note to.
             body (str): The body of the note.
             subject (str, optional): The subject of the note. Defaults to "".
+            retry (bool, optional): Whether to retry on failure. Defaults to True.
 
         Returns:
             bool: True if the note was added successfully, False otherwise.
@@ -298,6 +299,12 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
 
         if response.ok:
             return True
+
+        # Retry on contact not found error
+        if retry and "contact not found" in response.text.lower():
+            log("warn", f"Contact not found for person {person_id}. Retrying...")
+            time.sleep(random.uniform(5, 7))
+            return self._add_note(person_id, body, subject, retry=False)
 
         # Otherwise log the error and proceed
         log("error", f"Failed to add note to person {person_id}: {response.text}")


### PR DESCRIPTION
Sometimes, even when creating an Event object containing a person is successful, the subsequent note addition is unsuccessful and gives this error: `{"errorMessage":"Contact not found."}`

We catch this error specifically within the Follow Up Boss vanilla note-adding method and retry once, sleeping a uniformly distributed random number of seconds between 5 and 7. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced note-adding functionality with a retry mechanism for handling "contact not found" errors.
	- Improved error handling for rate-limiting scenarios.

- **Bug Fixes**
	- Adjusted logic to provide better feedback during note addition attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->