### PR TITLE
Flexible SDK model instantiation options

### DIFF
--- a/real_intent/schemas.py
+++ b/real_intent/schemas.py
@@ -1,5 +1,5 @@
 """Datatypes for working with the API."""
-from pydantic import BaseModel, Field, model_validator, field_validator
+from pydantic import BaseModel, Field, model_validator, field_validator, ConfigDict
 
 from typing import Any, Optional, Self
 from enum import Enum
@@ -123,6 +123,8 @@ class PII(BaseModel):
     Instantiate with `.from_api_dict` to ensure correct pre-processing of 
     mobile phone data.
     """
+    model_config = ConfigDict(populate_by_name=True)  # allow instantiating with python var names
+
     id: str = Field(..., alias="Id", description="BigDBM person ID")
     first_name: str = Field(..., alias="First_Name")
     last_name: str = Field(..., alias="Last_Name")


### PR DESCRIPTION
Allow models (namely, PII) to be instantiated with the variable-defined names instead of just the alias. 

Crucial for Webhawk PII cache. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization for the `PII` model, allowing for more flexible data handling.
	- Default values set for mobile phone data and improved handling of empty strings for investment types.
	- Improved data validation for gender values from the API.

- **Bug Fixes**
	- Ensured that missing email data is initialized to an empty list in the `PII` model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->