### PR TITLE
Allow CSV renames on formatter instantiation

### DIFF
--- a/real_intent/deliver/csv.py
+++ b/real_intent/deliver/csv.py
@@ -90,8 +90,13 @@ OUTPUT_COLUMNS: list[str] = [
 class CSVStringFormatter(BaseOutputDeliverer):
     """Format into CSV strings."""
 
-    def __init__(self, output_columns: list[str] = OUTPUT_COLUMNS):
+    def __init__(
+        self, 
+        output_columns: list[str] = OUTPUT_COLUMNS, 
+        renames: dict[str, str] | None = None
+    ):
         self.output_columns = [] + output_columns
+        self.renames = renames or {}
 
     @staticmethod
     def _unique_sentences(all_md5s: list[MD5WithPII]) -> set[str]:
@@ -144,6 +149,9 @@ class CSVStringFormatter(BaseOutputDeliverer):
             columns={sentence: sentence.split(">")[-1] for sentence in list_sentences}, 
             inplace=True
         )
+
+        # Execute renames if any
+        pii_df.rename(columns=self.renames, inplace=True)
 
         return pii_df
 

--- a/real_intent/deliver/csv_insights.py
+++ b/real_intent/deliver/csv_insights.py
@@ -9,8 +9,13 @@ class CSVWithInsightsFormatter(CSVStringFormatter):
     Format into CSV strings with insights.
     """
 
-    def __init__(self, per_lead_insights: dict[str, str], output_columns: list[str] = OUTPUT_COLUMNS):
-        super().__init__(output_columns)
+    def __init__(
+        self, 
+        per_lead_insights: dict[str, str], 
+        output_columns: list[str] = OUTPUT_COLUMNS,
+        renames: dict[str, str] | None = None
+    ):
+        super().__init__(output_columns, renames)
         self.per_lead_insights: dict[str, str] = per_lead_insights
 
     def _as_dataframe(self, pii_md5s: list[MD5WithPII]) -> DataFrame:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -20,6 +20,24 @@ def test_csv_string_formatter() -> None:
     assert len(csv_content.split('\n')) == 4  # 3 rows + empty line at the end
 
 
+def test_csv_string_formatter_renames() -> None:
+    formatter = CSVStringFormatter(renames={"test sentence": "thisrenamed"})
+    # Create two MD5WithPII objects with fake PII data
+    md5s: list[MD5WithPII] = [
+        MD5WithPII(md5="123abc", sentences=["test sentence"], pii=PII.create_fake(seed=42)),
+        MD5WithPII(md5="456def", sentences=["test sentence"], pii=PII.create_fake(seed=43))
+    ]
+    csv_content = formatter.deliver(md5s)
+    print("CSV CONTENT: \n", csv_content)
+    
+    # Check if the CSV contains the expected headers
+    expected_header = "thisrenamed,md5,first_name,last_name,address,city,state,zip_code,zip4,fips_state_code,fips_county_code,county_name,latitude,longitude,address_type,cbsa,census_tract,census_block_group,census_block,gender,scf,dma,msa,congressional_district,head_of_household,birth_month_and_year,age,prop_type,n_household_children,credit_range,household_income,household_net_worth,home_owner_status,marital_status,occupation,median_home_value,education,length_of_residence,n_household_adults,political_party,health_beauty_products,cosmetics,jewelry,investment_type,investments,pet_owner,pets_affinity,health_affinity,diet_affinity,fitness_affinity,outdoors_affinity,boating_sailing_affinity,camping_hiking_climbing_affinity,fishing_affinity,hunting_affinity,aerobics,nascar,scuba,weight_lifting,healthy_living_interest,motor_racing,foreign_travel,self_improvement,walking,fitness,ethnicity_detail,ethnic_group,email_1,email_2,email_3,phone_1,phone_1_dnc,phone_2,phone_2_dnc,phone_3,phone_3_dnc"
+    assert expected_header in csv_content
+    
+    # Check if the CSV contains the correct number of rows (header + 2 data rows)
+    assert len(csv_content.split('\n')) == 4  # 3 rows + empty line at the end
+
+
 def test_csv_string_formatter_empty_input() -> None:
     formatter = CSVStringFormatter()
     md5s: list[MD5WithPII] = []


### PR DESCRIPTION
Allow base CSV formatter to accept a `renames: dict[str, str] | None = None` and then apply this to `_as_dataframe`. 

Same for insights CSV formatter, but this calls `super()._as_dataframe(...)` so implicitly implemented. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced optional column renaming functionality in the CSV output for enhanced customization.
  - Added support for dynamic renaming of columns in both `CSVStringFormatter` and `CSVWithInsightsFormatter`.
  
- **Tests**
  - Added a new test to validate the renaming feature in `CSVStringFormatter`, ensuring expected behavior and consistency in output.

These updates improve the flexibility of CSV exports, allowing users to tailor column names according to their preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->