### PR TITLE
Validation for 75k- incomes

### DIFF
--- a/real_intent/validate/pii.py
+++ b/real_intent/validate/pii.py
@@ -83,6 +83,26 @@ class MidIncomeValidator(BaseValidator):
             md5 for md5 in md5s 
             if md5.pii.household_income in income_levels
         ]
+
+
+class HighIncomeValidator(BaseValidator):
+    """Remove leads below $75k income."""
+
+    def _validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
+        """Remove leads that do not match the high income requirement."""
+        income_levels = {
+            "H. $75,000-$99,999",
+            "K. $100,000-$149,999", 
+            "L. $150,000-$174,999", 
+            "M. $175,000-$199,999", 
+            "N. $200,000-$249,999", 
+            "O. $250K +"
+        }
+        
+        return [
+            md5 for md5 in md5s 
+            if md5.pii.household_income in income_levels
+        ]
         
 
 class MNWValidator(BaseValidator):


### PR DESCRIPTION
Implement high income validator for anything under $75k per household. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `HighIncomeValidator` class to filter leads based on a minimum income threshold of $75,000, enhancing the existing validation framework for personal identifiable information (PII).
  
- **Bug Fixes**
  - Maintained existing logic in other validators to ensure consistent functionality across income and net worth thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->