### PR TITLE
Add profile-aware context to LLMs at insight generation

### DIFF
--- a/real_intent/analyze/insights/many.py
+++ b/real_intent/analyze/insights/many.py
@@ -9,7 +9,7 @@ from real_intent.analyze.insights.validator_prompt import SYSTEM_PROMPT as VALID
 
 from real_intent.deliver.csv import CSVStringFormatter
 from real_intent.validate.base import BaseValidator
-from real_intent.process.base import BaseProcessor, ProcessValidator
+from real_intent.process.base import BaseProcessor
 from real_intent.internal_logging import log
 from real_intent.utils import retry_with_backoff
 

--- a/real_intent/analyze/insights/many.py
+++ b/real_intent/analyze/insights/many.py
@@ -256,7 +256,7 @@ class ValidatedInsightsGenerator(BaseAnalyzer):
         @retry_with_backoff()
         def generate_insights():
             return self.openai_client.beta.chat.completions.parse(
-                model="gpt-4o-2024-08-06",
+                model="gpt-4o",
                 messages=[
                     {
                         "role": "system",

--- a/real_intent/analyze/insights/many.py
+++ b/real_intent/analyze/insights/many.py
@@ -82,7 +82,7 @@ class OpenAIInsightsGenerator(BaseAnalyzer):
         @retry_with_backoff()
         def generate_insights():
             return self.openai_client.beta.chat.completions.parse(
-                model="gpt-4o-2024-08-06",
+                model="gpt-4o",
                 messages=[
                     {
                         "role": "system",

--- a/real_intent/analyze/insights/many.py
+++ b/real_intent/analyze/insights/many.py
@@ -172,6 +172,7 @@ class ValidatedInsightsGenerator(BaseAnalyzer):
             self, 
             openai_api_key: str, 
             processor: BaseProcessor,
+            profile: str = ""
         ):
         """
         Initialize the ValidatedInsightsGenerator.
@@ -191,6 +192,7 @@ class ValidatedInsightsGenerator(BaseAnalyzer):
         
         self.openai_client: OpenAI = OpenAI(api_key=openai_api_key)
         self.processor: BaseProcessor = processor
+        self.profile: str = profile or "n/a / unclear"
 
     def extract_validation_info(self) -> str:
         """
@@ -265,6 +267,7 @@ class ValidatedInsightsGenerator(BaseAnalyzer):
                     {
                         "role": "user",
                         "content": (
+                            f"Profile: {self.profile}\n\n"
                             f"Validations:\n\n{validation_info}\n\n"
                             f"Leads:\n\n{csv_data}"
                         )

--- a/real_intent/analyze/insights/per_lead.py
+++ b/real_intent/analyze/insights/per_lead.py
@@ -16,7 +16,9 @@ Your individual lead insight should be NO MORE than 2 sentences long.
 It's extremely important that you think deeply and critically. Think like a subject-matter expert, thinking through the overall insights and how this individual lead fits into the bigger picture. 
 Think about how somebody receiving this lead can make the most of it. Actionable insights are key. 
 
-Your response must be valid JSON with the specified keys. Use the "thinking" key FIRST to think thoroughly and critically through your process, before arriving at your final insight.
+You will be given a "Profile" which is a brief descriptor of the overall category of the IAB categories, so you can make assumptions about who the leads are for and how the recipient of the leads should optimize usage of the leads.
+
+Your response must be valid JSON with the specified keys. Use the "thinking" key FIRST to think thoroughly and critically through your process, before arriving at your final insight. Consider the provided profile when generating your insight.
 """
 
 
@@ -30,18 +32,20 @@ class LeadInsight(BaseModel):
 class PerLeadInsightGenerator(BaseAnalyzer):
     """Generate insights for each lead."""
 
-    def __init__(self, openai_api_key: str, global_insights: str = "") -> None:
+    def __init__(self, openai_api_key: str, global_insights: str = "", profile: str = "") -> None:
         """
         Initialize the PerLeadInsightGenerator.
 
         Args:
             openai_api_key: The API key for OpenAI.
             global_insights: Global insights to consider for each lead.
+            profile: Profile to consider for each lead.
 
         Raises:
             ImportError: If the OpenAI package is not installed.
         """
         self.global_insights = global_insights
+        self.profile = profile or "n/a / unclear"
 
         try:
             from openai import OpenAI, OpenAIError
@@ -92,6 +96,7 @@ class PerLeadInsightGenerator(BaseAnalyzer):
                     {
                         "role": "user",
                         "content": (
+                            f"Profile: {self.profile}\n\n"
                             f"Overall Insights:\n\n{self.global_insights}\n\n"
                             f"Lead:\n\n{lead_csv}"
                         )

--- a/real_intent/analyze/insights/per_lead.py
+++ b/real_intent/analyze/insights/per_lead.py
@@ -83,7 +83,7 @@ class PerLeadInsightGenerator(BaseAnalyzer):
         @retry_with_backoff()
         def generate_insight():
             return self.openai_client.beta.chat.completions.parse(
-                model="gpt-4o-2024-08-06",
+                model="gpt-4o",
                 messages=[
                     {
                         "role": "system",

--- a/real_intent/analyze/insights/validator_prompt.py
+++ b/real_intent/analyze/insights/validator_prompt.py
@@ -2,7 +2,7 @@
 
 SYSTEM_PROMPT = r"""You are a lead generation expert. You take a CSV string of a list of leads with all necessary metadata and come up with useful insights based on the specific set of leads. 
 
-The leads are intent based, meaning they're aggregated based on IAB intent categories (each category is a column in the CSV). Your insights should center around these IAB categories, using the personal information of each lead (age, demographics, income, gender, etc.) to create insights and narratives that will help to understand how to sell to these leads. 
+The leads are intent based, meaning they're aggregated based on IAB intent categories (each category is a column in the CSV). Your insights should center around these IAB categories, using the personal information of each lead (age, demographics, income, gender, etc.) to create insights and narratives that will help to understand how to sell to these leads. You will be given a "Profile" which is a brief descriptor of the overall category of the IAB categories, so you can make assumptions about who the leads are for and how the recipient of the leads should optimize usage of the leads.
 
 Aside from providing the leads directly, the leads have been 'validated' using a set of 'validators'. You will be provided the validators with names and descriptions. 
 Use this understanding of what validation was applied to the leads to provide a validation insight.
@@ -21,6 +21,8 @@ How validation works: each validator has an integer priority, with lower integer
 The system starts by using all validators, and iteratively removes a priority rung of validators (lowest priority, i.e. highest integer) if enough leads are not found with all priorities given. The highest priority validators, i.e. priority 1, cannot be removed - if leads do not pass priority 1 validation, they may not be returned. These validators are broken down by priority rung for you. 
 
 For example, given these validations and leads as an input (leads and validations are fake, but the structure is real):
+
+Profile: RealEstateBroker
 
 Validations:
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -72,6 +72,27 @@ def test_validated_insights_generator(bigdbm_client) -> None:
 
 
 @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OpenAI API key not found")
+def test_validated_insights_generator_with_profile(bigdbm_client) -> None:
+    api_key = os.getenv("OPENAI_API_KEY")
+
+    processor = FillProcessor(bigdbm_client)
+    processor.add_validator(SamePersonValidator())
+    processor.add_validator(MNWValidator(), priority=2)
+
+    profile = "Automotive / Vehicle Shopping"
+    generator = ValidatedInsightsGenerator(api_key, processor, profile=profile)
+    # Create MD5WithPII objects with fake PII data and specific sentences
+    md5s = [
+        MD5WithPII(md5="123", sentences=["Interested in buying a new car"], pii=PII.create_fake(seed=42)),
+        MD5WithPII(md5="456", sentences=["Looking for auto insurance"], pii=PII.create_fake(seed=43))
+    ]
+    result = generator.analyze(md5s)
+    assert isinstance(result, str)
+    assert "On validation:" in result
+    assert len(result.split("\n")) >= 3  # Expecting validation insight and at least two regular insights
+
+
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OpenAI API key not found")
 def test_individual_insights_generator(bigdbm_client) -> None:
     api_key = os.getenv("OPENAI_API_KEY")
 
@@ -88,6 +109,35 @@ def test_individual_insights_generator(bigdbm_client) -> None:
     result = generator.analyze(md5s)
 
     individual_generator = PerLeadInsightGenerator(api_key, result)
+    insights = individual_generator.analyze(md5s)
+
+    assert isinstance(insights, dict)
+    assert len(insights) == 2
+
+    for md5, insight in insights.items():
+        assert isinstance(md5, str)
+        assert isinstance(insight, str)
+        assert len(insight) > 0
+
+
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OpenAI API key not found")
+def test_individual_insights_generator_with_profile(bigdbm_client) -> None:
+    api_key = os.getenv("OPENAI_API_KEY")
+
+    processor = FillProcessor(bigdbm_client)
+    processor.add_validator(SamePersonValidator())
+    processor.add_validator(MNWValidator(), priority=2)
+
+    profile = "Automotive / Vehicle Shopping"
+    generator = ValidatedInsightsGenerator(api_key, processor, profile=profile)
+    # Create MD5WithPII objects with fake PII data and specific sentences
+    md5s = [
+        MD5WithPII(md5="123", sentences=["Interested in buying a new car"], pii=PII.create_fake(seed=42)),
+        MD5WithPII(md5="456", sentences=["Looking for auto insurance"], pii=PII.create_fake(seed=43))
+    ]
+    result = generator.analyze(md5s)
+
+    individual_generator = PerLeadInsightGenerator(api_key, result, profile=profile)
     insights = individual_generator.analyze(md5s)
 
     assert isinstance(insights, dict)


### PR DESCRIPTION
Closes #131.

Add profile parameter to insights generators to provide context about lead categories.

This PR adds a new `profile` parameter to both ValidatedInsightsGenerator and PerLeadInsightGenerator, allowing the LLM to better understand the context of the leads it's analyzing. The profile is a brief descriptor of the overall category of the IAB categories, helping the model make more informed assumptions about who the leads are for and how they should be used.

Key Changes:
- Added `profile` parameter (defaulting to "n/a / unclear") to ValidatedInsightsGenerator and PerLeadInsightGenerator
- Updated system prompts to incorporate the profile information when generating insights
- Added comprehensive tests for both generators with profile parameter
- Fixed model name from "gpt-4o-2024-08-06" to "gpt-4o"
- Removed unused ProcessValidator import

The profile parameter helps the LLM:
1. Better understand the target audience for the leads
2. Generate more contextually relevant insights
3. Provide more actionable recommendations based on the specific industry/category

Example usage:
```python
generator = ValidatedInsightsGenerator(
    api_key,
    processor,
    profile="RealEstateBroker"
)
```

Tests have been added to verify both generators work correctly with and without the profile parameter specified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced insights generation by incorporating a profile context for improved relevance.
  - Updated prompts to include profile information for better context during analysis.

- **Bug Fixes**
  - Streamlined model specification for generating insights.

- **Tests**
  - Added tests for the new profile parameter in both the `ValidatedInsightsGenerator` and `PerLeadInsightGenerator` to ensure functionality and output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->