### PR TITLE
Create an apartment validator

### DIFF
--- a/real_intent/schemas.py
+++ b/real_intent/schemas.py
@@ -338,7 +338,7 @@ class PII(BaseModel):
             "County_Name": f"{random.choice(['North', 'South', 'East', 'West'])} County",
             "Latitude": str(lat),
             "Longitude": str(lon),
-            "Address_Type": random.choice(["Residential", "Business"]),
+            "Address_Type": random.choice(["H", "S", ""]),
             "Cbsa": str(random.randint(10000,99999)),
             "Census_Tract": str(random.randint(100000,999999)),
             "Census_Block_Group": str(random.randint(1,9)),

--- a/real_intent/validate/home_attrs.py
+++ b/real_intent/validate/home_attrs.py
@@ -14,10 +14,10 @@ class NotRenterValidator(BaseValidator):
 
 
 class NotApartmentValidator(BaseValidator):
-    """Remove leads where property type indicates they're in an apartment."""
+    """Remove leads where address type indicates they're in an apartment."""
 
     def _validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
         """Remove leads that are in an apartment."""
         return [
-            md5 for md5 in md5s if md5.pii.prop_type != "H"  # observed behavior
+            md5 for md5 in md5s if md5.pii.address_type != "H"  # observed behavior
         ]

--- a/real_intent/validate/home_attrs.py
+++ b/real_intent/validate/home_attrs.py
@@ -11,3 +11,13 @@ class NotRenterValidator(BaseValidator):
         return [
             md5 for md5 in md5s if md5.pii.home_owner_status != "Renter"
         ]
+
+
+class NotApartmentValidator(BaseValidator):
+    """Remove leads where property type indicates they're in an apartment."""
+
+    def _validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
+        """Remove leads that are in an apartment."""
+        return [
+            md5 for md5 in md5s if md5.pii.prop_type != "H"  # observed behavior
+        ]


### PR DESCRIPTION
Observed behavior has to do with the `prop_type` being "H" so clear this out with a new `NotApartmentValidator` class. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new validation feature to filter out leads that indicate they are in an apartment.
	- Updated data generation for address types to use single-character codes for improved consistency.
- **Bug Fixes**
	- Enhanced lead validation logic to ensure more accurate filtering based on property type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->