### PR TITLE
Improve event generation unit tests

### DIFF
--- a/tests/test_events_generator.py
+++ b/tests/test_events_generator.py
@@ -1,23 +1,25 @@
 """Test the event generators (Scrapybara and Perplexity)."""
 import pytest
-import os
-import warnings
 from dotenv import load_dotenv
-import datetime
-import re
 
-# Suppress reportlab deprecation warning
-warnings.filterwarnings(
-    "ignore",
-    message="ast.NameConstant is deprecated",
-    category=DeprecationWarning
-)
+import os
+import re
+import warnings
+import datetime
 
 from real_intent.events import (
     Event,
     EventsResponse,
     PerplexityEventsGenerator,
     ScrapybaraEventsGenerator
+)
+from real_intent.events.errors import NoEventsFoundError
+
+# Suppress reportlab deprecation warning
+warnings.filterwarnings(
+    "ignore",
+    message="ast.NameConstant is deprecated",
+    category=DeprecationWarning
 )
 
 # Load environment variables
@@ -174,7 +176,10 @@ def test_invalid_api_key_scrapybara():
 
 def test_chicago_events_perplexity(perplexity_events_generator):
     """Test generating events for Chicago (60629) using Perplexity."""
-    response = perplexity_events_generator.generate("60629")
+    try:
+        response = perplexity_events_generator.generate("60629")
+    except NoEventsFoundError:
+        pytest.skip("No events found for this zip code.")
     
     # Verify response structure
     assert isinstance(response, EventsResponse)

--- a/tests/test_events_generator.py
+++ b/tests/test_events_generator.py
@@ -172,9 +172,9 @@ def test_invalid_api_key_scrapybara():
         ScrapybaraEventsGenerator(None, None)
 
 
-def test_beverly_hills_events_perplexity(perplexity_events_generator):
-    """Test generating events for Beverly Hills (90210) using Perplexity."""
-    response = perplexity_events_generator.generate("90210")
+def test_chicago_events_perplexity(perplexity_events_generator):
+    """Test generating events for Chicago (60629) using Perplexity."""
+    response = perplexity_events_generator.generate("60629")
     
     # Verify response structure
     assert isinstance(response, EventsResponse)
@@ -193,6 +193,7 @@ def test_beverly_hills_events_perplexity(perplexity_events_generator):
         # Extract and verify date
         date_str = extract_date_from_range(event.date)
         event_date = datetime.datetime.strptime(date_str, "%Y-%m-%d")
+
         # Allow events within the next month
         today = (datetime.datetime.now() - datetime.timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)  # 1 day grace period
         month_from_now = today + datetime.timedelta(days=32)  # ~1 month + 1 day grace period
@@ -203,7 +204,7 @@ def test_beverly_hills_events_perplexity(perplexity_events_generator):
     
     # Verify summary
     assert len(response.summary.split()) >= 20, "Summary should be meaningful"
-    assert "Beverly Hills" in response.summary, "Summary should mention Beverly Hills"
+    assert "Chicago" in response.summary, "Summary should mention Chicago"
 
 
 def test_invalid_zip_code_perplexity(perplexity_events_generator):


### PR DESCRIPTION
Don't want unreliable tests, the Perplexity one was a crapshoot. With fail-fast, event generation failure means the whole test suite fails. So, we use the country's most populous zipcode 60629 for Perplexity tests, and catch `NoEventsFoundError` to skip the test. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test case to focus on Chicago events instead of Beverly Hills
	- Improved error handling for event generation tests
	- Enhanced import statements for better environment variable and error management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->