### PR TITLE
More reliable event generator test

### DIFF
--- a/tests/test_events_generator.py
+++ b/tests/test_events_generator.py
@@ -205,11 +205,10 @@ def test_chicago_events_perplexity(perplexity_events_generator):
         assert today <= event_date <= month_from_now, f"Event date {event_date} should be within the next month"
         
         # Verify description is meaningful
-        assert len(event.description.split()) >= 10, "Description should be meaningful"
+        assert len(event.description.split()) >= 10, "Description should be meaningful (at least 10 words)"
     
     # Verify summary
-    assert len(response.summary.split()) >= 20, "Summary should be meaningful"
-    assert "Chicago" in response.summary, "Summary should mention Chicago"
+    assert len(response.summary.split()) >= 20, "Summary should be meaningful (at least 20 words)"
 
 
 def test_invalid_zip_code_perplexity(perplexity_events_generator):


### PR DESCRIPTION
Asserting the presence of "Chicago" in the summary was a bit of a crapshoot. Remove for more reliability and improve messages in prior assertions. 