### PR TITLE
Fix FUB integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def generate_random_name(length=6):
 def sample_pii_md5s():
     """Create a sample MD5WithPII object using fake PII data."""
     # Create fake PII with a fixed seed for reproducibility
-    pii = PII.create_fake(seed=42)
+    pii = PII.create_fake()
     
     # Create MD5WithPII with the fake PII
     return [

--- a/tests/test_followupboss.py
+++ b/tests/test_followupboss.py
@@ -78,7 +78,7 @@ def test_followupboss_deliverer_success(followupboss_deliverer, sample_pii_md5s)
     assert set(event_data["person"]["tags"]) == set(expected_tags), "Prepared event data does not contain the correct tags"
 
     # Test delivery and verify tags in the result
-    result = followupboss_deliverer.deliver(sample_pii_md5s)
+    result = followupboss_deliverer.deliver([sample_pii_md5s[0]])
 
     assert len(result) == 1
     assert "id" in result[0]
@@ -114,7 +114,7 @@ def test_prepare_event_data(followupboss_deliverer, sample_pii_md5s):
     assert event_data["system"] == followupboss_deliverer.system
     assert event_data["person"]["firstName"] == sample_pii_md5s[0].pii.first_name
     assert event_data["person"]["lastName"] == sample_pii_md5s[0].pii.last_name
-    assert event_data["person"]["emails"] == [{"value": sample_pii_md5s[0].pii.emails[0]}]
+    assert sample_pii_md5s[0].pii.emails[0] in [email["value"] for email in event_data["person"]["emails"]]
     assert event_data["person"]["addresses"] == [{
         "type": "home",
         "street": sample_pii_md5s[0].pii.address,


### PR DESCRIPTION
Tests have been failing since changing the fake creation method of `PII`, after debugging it's due to the seed in conftests being hardcoded at `42`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated `FollowUpBossDeliverer` test cases to:
		- Test delivery with a single PII data entry
		- Modify email validation logic in event data preparation
	- Modified PII data generation fixture to use non-deterministic seed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->