### PR TITLE
Improve error handling for Follow Up Boss integration

### DIFF
--- a/real_intent/deliver/followupboss/__init__.py
+++ b/real_intent/deliver/followupboss/__init__.py
@@ -1,3 +1,3 @@
 """Deliverers to interact with Follow Up Boss."""
-from real_intent.deliver.followupboss.vanilla import FollowUpBossDeliverer, InvalidAPICredentialsError
+from real_intent.deliver.followupboss.vanilla import FollowUpBossDeliverer, InvalidAPICredentialsError, AccountInactiveError
 from real_intent.deliver.followupboss.ai_fields import AIFollowUpBossDeliverer

--- a/real_intent/deliver/followupboss/__init__.py
+++ b/real_intent/deliver/followupboss/__init__.py
@@ -1,3 +1,3 @@
 """Deliverers to interact with Follow Up Boss."""
-from real_intent.deliver.followupboss.vanilla import FollowUpBossDeliverer, InvalidAPICredentialsError, AccountInactiveError
+from real_intent.deliver.followupboss.vanilla import FollowUpBossDeliverer, InvalidFUBCredentialsError, AccountInactiveError
 from real_intent.deliver.followupboss.ai_fields import AIFollowUpBossDeliverer

--- a/real_intent/deliver/followupboss/ai_fields.py
+++ b/real_intent/deliver/followupboss/ai_fields.py
@@ -7,10 +7,12 @@ from typing import Literal, Any
 import time
 
 from real_intent.schemas import MD5WithPII
-from real_intent.deliver.followupboss.vanilla import FollowUpBossDeliverer, EventType, InvalidAPICredentialsError, fub_rate_limited
+from real_intent.deliver.followupboss.vanilla import FollowUpBossDeliverer, EventType, fub_rate_limited
 from real_intent.deliver.followupboss.ai_prompt import SYSTEM_PROMPT
 from real_intent.internal_logging import log, log_span
 
+
+# ---- Models ----
 
 class CustomField(BaseModel):
     """Custom field in Follow Up Boss."""
@@ -47,6 +49,14 @@ class CustomFieldCreation(BaseModel):
         )
     )
 
+
+# ---- Errors ----
+
+class InvalidOpenAICredentialsError(Exception):
+    """Raised when invalid OpenAI API credentials are provided."""
+
+
+# ---- Deliverer ----
 
 class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
     """
@@ -110,7 +120,7 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
         self.openai_client = openai.OpenAI(api_key=openai_api_key)
 
         if not self._verify_openai_credentials():
-            raise InvalidAPICredentialsError("Invalid API credentials provided for OpenAI.")
+            raise InvalidOpenAICredentialsError("Invalid API credentials provided for OpenAI.")
 
         # Cache the custom fields
         self.custom_fields: list[CustomField] = []

--- a/real_intent/deliver/followupboss/vanilla.py
+++ b/real_intent/deliver/followupboss/vanilla.py
@@ -35,7 +35,7 @@ class EventType(StrEnum):
 
 # ---- Errors ----
 
-class InvalidAPICredentialsError(Exception):
+class InvalidFUBCredentialsError(Exception):
     """Raised when invalid API credentials are provided."""
 
 
@@ -108,7 +108,7 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
 
         # Make sure API credentials are valid
         if not self._verify_api_credentials():
-            raise InvalidAPICredentialsError("Invalid API credentials provided for FollowUpBoss.")
+            raise InvalidFUBCredentialsError("Invalid API credentials provided for FollowUpBoss.")
 
         # Make sure the account is active
         if not self._verify_account_active():

--- a/tests/test_followupboss.py
+++ b/tests/test_followupboss.py
@@ -6,8 +6,8 @@ from dotenv import load_dotenv
 import string
 import random
 
-from real_intent.deliver.followupboss import FollowUpBossDeliverer, InvalidAPICredentialsError
-from real_intent.deliver.followupboss.ai_fields import AIFollowUpBossDeliverer
+from real_intent.deliver.followupboss import FollowUpBossDeliverer, InvalidFUBCredentialsError
+from real_intent.deliver.followupboss.ai_fields import AIFollowUpBossDeliverer, InvalidOpenAICredentialsError
 
 
 # Load environment variables from .env file
@@ -178,7 +178,7 @@ def test_vanilla_followupboss_credential_validation(api_key, system, system_key)
     FollowUpBossDeliverer(api_key, system, system_key)
 
     # Test invalid credentials and ensure that they don't throw exception
-    with pytest.raises(InvalidAPICredentialsError):
+    with pytest.raises(InvalidFUBCredentialsError):
         FollowUpBossDeliverer("invalid_api_key", system, system_key)
 
 
@@ -194,11 +194,11 @@ def test_ai_followupboss_credential_validation(api_key, system, system_key, open
     AIFollowUpBossDeliverer(api_key, system, system_key, openai_api_key)
 
     # Test invalid credentials and ensure that they don't throw exception
-    with pytest.raises(InvalidAPICredentialsError):
+    with pytest.raises(InvalidFUBCredentialsError):
         AIFollowUpBossDeliverer("invalid_api_key", system, system_key, openai_api_key)
 
     # Test OpenAI API key validation
-    with pytest.raises(InvalidAPICredentialsError):
+    with pytest.raises(InvalidOpenAICredentialsError):
         AIFollowUpBossDeliverer(api_key, system, system_key, "invalid_openai_api_key")
 
 


### PR DESCRIPTION
- Rename InvalidAPICredentialsError to InvalidFUBCredentialsError for better clarity
- Add dedicated InvalidOpenAICredentialsError class for OpenAI authentication failures
- Update imports and error handling code to use new error classes
- Expose both deliverers (FollowUpBossDeliverer, AIFollowUpBossDeliverer) and all error classes (InvalidFUBCredentialsError, InvalidOpenAICredentialsError, AccountInactiveError) directly from real_intent.deliver.followupboss package