### PR TITLE
Don't log trace access token updated

### DIFF
--- a/real_intent/client.py
+++ b/real_intent/client.py
@@ -64,8 +64,6 @@ class BigDBMClient:
         with self._token_lock:
             self._access_token = response_json["access_token"]
             self._access_token_expiration = int(time.time() - 10) + response_json["expires_in"]
-        
-        log("trace", "Updated access token.")
 
     def _access_token_valid(self) -> bool:
         """


### PR DESCRIPTION
Was cluttering the log space severely, especially for Webhawk with 9 concurrent workers and multiple live instances.