### PR TITLE
Zapier: Don't stringify nonexistent values

### DIFF
--- a/real_intent/deliver/zapier/__init__.py
+++ b/real_intent/deliver/zapier/__init__.py
@@ -155,10 +155,9 @@ class ZapierDeliverer(BaseOutputDeliverer):
         for pii_md5 in pii_md5s:
             md5_dict: dict[str, Any] = self._convert_dict_lead_export(pii_md5)
 
-            # convert all values to string, needed for Zapier consistency
+            # convert all present values to string, needed for Zapier consistency
             md5_dict["pii"] = {
-                key: (str(value)) for key, value in md5_dict["pii"].items()
-                if value is not None
+                key: str(value) if value is not None else None for key, value in md5_dict["pii"].items()
             }
 
             md5_dict["insight"] = self.per_lead_insights.get(md5_dict["md5"], "")

--- a/real_intent/deliver/zapier/__init__.py
+++ b/real_intent/deliver/zapier/__init__.py
@@ -156,7 +156,10 @@ class ZapierDeliverer(BaseOutputDeliverer):
             md5_dict: dict[str, Any] = self._convert_dict_lead_export(pii_md5)
 
             # convert all values to string, needed for Zapier consistency
-            md5_dict["pii"] = {key: (str(value)) for key, value in md5_dict["pii"].items()}
+            md5_dict["pii"] = {
+                key: (str(value)) for key, value in md5_dict["pii"].items()
+                if value is not None
+            }
 
             md5_dict["insight"] = self.per_lead_insights.get(md5_dict["md5"], "")
             md5_dict["sentences"] = ", ".join(md5_dict["sentences"])

--- a/tests/test_zapier.py
+++ b/tests/test_zapier.py
@@ -77,7 +77,7 @@ def test_format(generate_md5withpii):
 
     expected_data = [{
         "md5": "123",
-        "pii": {key: str(value) for key, value in test1.pii.as_lead_export().items() if value is not None},
+        "pii": {key: str(value) if value is not None else None for key, value in test1.pii.as_lead_export().items()},
         "insight": "Insight for first md5 123",
         "sentences": "test sentence for first md5 123", 
         "date_delivered": datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/test_zapier.py
+++ b/tests/test_zapier.py
@@ -77,7 +77,7 @@ def test_format(generate_md5withpii):
 
     expected_data = [{
         "md5": "123",
-        "pii": {key: (str(value)) for key, value in test1.pii.as_lead_export().items()},
+        "pii": {key: str(value) for key, value in test1.pii.as_lead_export().items() if value is not None},
         "insight": "Insight for first md5 123",
         "sentences": "test sentence for first md5 123", 
         "date_delivered": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -88,4 +88,3 @@ def test_format(generate_md5withpii):
     assert formatted_data[0]["insight"] == expected_data[0]["insight"]
     assert formatted_data[0]["sentences"] == expected_data[0]["sentences"]
     assert formatted_data[0]["date_delivered"].startswith(datetime.now().strftime("%Y-%m-%d"))
-


### PR DESCRIPTION
Instead of `str(key): value`, do `str(key): value if value is not None else None` to include empty values as `None` not `"None"`. 