### PR TITLE
Standardize mock PII birthday format

### DIFF
--- a/real_intent/schemas.py
+++ b/real_intent/schemas.py
@@ -321,7 +321,7 @@ class PII(BaseModel):
         today = datetime.now()
         birth_date = today - timedelta(days=random.randint(365*18, 365*80))  # Between 18 and 80 years old
         age = str((today - birth_date).days // 365)
-        birth_month_year = birth_date.strftime("%m/%Y")
+        birth_month_year = birth_date.strftime(r"%m/%d/%Y")
 
         # Generate random coordinates in continental US
         lat = random.uniform(24.396308, 49.384358)  # Approximate US boundaries


### PR DESCRIPTION
Closes #188. 

Ensure the format is `%m/%d/%Y` same as live data. Previously the mock data was giving just `%m/%Y`. 