### PR TITLE
Fix the use of exc_info in logs

### DIFF
--- a/real_intent/events/scrapy_claude/__init__.py
+++ b/real_intent/events/scrapy_claude/__init__.py
@@ -54,7 +54,7 @@ def log_step(step: Step) -> None:
             if tool_result.is_error:
                 log("debug", f"Tool Error: {result.error}")
     except Exception as e:
-        log("error", f"Error processing step: {e}", _exc_info=e)
+        log("error", f"Error processing step: {e}", exc_info=e)
 
 
 # ---- Implementation ----


### PR DESCRIPTION
One incorrect use, passing `_exc_info` instead of `exc_info`. 