### PR TITLE
Intent API v2

### DIFF
--- a/real_intent/client.py
+++ b/real_intent/client.py
@@ -226,12 +226,14 @@ class BigDBMClient:
 
     def _extract_intent_events(self, fetch_result_json: dict) -> list[IntentEvent]:
         """Pull the intent events listed on a job's results page."""
+        log("trace", f"Extracting intent events from: {fetch_result_json}")
+
         intent_events = [
             IntentEvent(
-                md5=obj["mD5"],
-                sentence=obj["sentence"]
+                md5=obj["MD5"],
+                sentence=obj["Sentence"]
             )
-            for obj in fetch_result_json["result"]
+            for obj in fetch_result_json["results"]
         ]
 
         log("trace", f"Extracted intent events: {intent_events}")
@@ -242,7 +244,7 @@ class BigDBMClient:
         # First page
         PER_PAGE_COUNT: int = 100
         response_json: dict = self._fetch_result_response(list_queue_id, 1)
-        total_count: int = int(response_json["totalCount"])
+        total_count: int = int(response_json["count"])
         page_count: int = (total_count // PER_PAGE_COUNT) + 1
         intent_events: list[IntentEvent] = self._extract_intent_events(response_json)
 

--- a/real_intent/client.py
+++ b/real_intent/client.py
@@ -135,7 +135,7 @@ class BigDBMClient:
         response_json: dict[str, str] = self._request(
             Request(
                 method="GET",
-                url="https://aws-prod-intent-api.bigdbm.com/intent/configData",
+                url="https://sjbj20ixy5.execute-api.us-west-2.amazonaws.com/Prod/intent/configData",
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded"
                 }
@@ -160,7 +160,7 @@ class BigDBMClient:
         log("trace", f"Creating IABJob: {iab_job}")
         request = Request(
             method="POST",
-            url="https://aws-prod-intent-api.bigdbm.com/intent/createList",
+            url="https://sjbj20ixy5.execute-api.us-west-2.amazonaws.com/Prod/intent/createList",
             headers={
                 "Content-Type": "application/json"
             },
@@ -180,7 +180,7 @@ class BigDBMClient:
         """Get the processing status of a list."""
         request = Request(
             method="GET",
-            url="https://aws-prod-intent-api.bigdbm.com/intent/checkList",
+            url="https://sjbj20ixy5.execute-api.us-west-2.amazonaws.com/Prod/intent/checkList",
             params={"listQueueId": list_queue_id}
         )
 
@@ -217,7 +217,7 @@ class BigDBMClient:
         """Return the JSON API response when pulling a page's results."""
         request = Request(
             method="POST",
-            url="https://aws-prod-intent-api.bigdbm.com/intent/result",
+            url="https://sjbj20ixy5.execute-api.us-west-2.amazonaws.com/Prod/intent/result",
             headers={"Content-Type": "application/json"},
             json={"ListQueueId": list_queue_id, "Page": page_num}
         )
@@ -322,7 +322,7 @@ class BigDBMClient:
             
             request = Request(
                 method="POST",
-                url="https://aws-prod-intent-api.bigdbm.com/intent/queueCount",                
+                url="https://sjbj20ixy5.execute-api.us-west-2.amazonaws.com/Prod/intent/queueCount",                
                 headers={"Content-Type": "application/json"},
                 json={
                     "StartDate": config_dates.start_date, 
@@ -339,7 +339,7 @@ class BigDBMClient:
             # After job completion, fetch the result count
             request_count = Request(
                 method="POST",
-                url="https://aws-prod-intent-api.bigdbm.com/intent/resultCount",
+                url="https://sjbj20ixy5.execute-api.us-west-2.amazonaws.com/Prod/intent/resultCount",
                 headers={"Content-Type": "application/json"},
                 json={"ListQueueId": list_queue_id}
             )

--- a/real_intent/schemas.py
+++ b/real_intent/schemas.py
@@ -7,7 +7,7 @@ import random
 import string
 from datetime import datetime, timedelta
 
-from real_intent.taxonomy import code_to_category
+from real_intent.taxonomy import code_to_category, category_to_code
 
 
 class ConfigDates(BaseModel):
@@ -51,7 +51,7 @@ class IABJob(BaseModel):
     def as_payload(self) -> dict[str, str | int]:
         """Convert into dictionary payload."""
         return {
-            "IABs": ",".join(self.intent_categories),
+            "IABs": ",".join(str(category_to_code(category)) for category in self.intent_categories),
             "Zips": ",".join(self.zips),
             "Keywords": ",".join(self.keywords),
             "Domains": ",".join(self.domains),

--- a/real_intent/taxonomy.py
+++ b/real_intent/taxonomy.py
@@ -52,3 +52,14 @@ def code_to_category(code: str | int | None) -> str:
         return str(code)
 
     return str(result.iloc[0]["IAB_Category_Name"])
+
+
+@lru_cache(maxsize=None)
+def category_to_code(category: str) -> int | None:
+    """Return the code for a given category."""
+    result: pd.DataFrame = taxonomy_df[taxonomy_df["IAB_Category_Name"] == category]
+
+    if result.empty:
+        return None
+
+    return int(result.iloc[0]["IAB_Category_ID"])


### PR DESCRIPTION
Closes #210. Allows concurrency of 20.

- Creating list now requires IAB IDs vs strings
- Field name of /result for total count is now "count" not "totalCount"
- Field name of /result for results is now "results" not "result"
- Field names of nested objects within /result -> "results" are now in pascal case (except for md5 -> "MD5").

The conversion process (reverse) to build IAB payload is much more robust as it's type- and value-aware in deciding converter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced logic for converting intent category names into standardized codes with caching support for improved accuracy.

- **Chores**
  - Updated service connections to use new endpoints, ensuring improved reliability.
  - Refined data processing of API responses for consistent and accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->