### PR TITLE
Create a zipcode exclusion validator

### DIFF
--- a/real_intent/validate/simple.py
+++ b/real_intent/validate/simple.py
@@ -21,6 +21,25 @@ class ZipCodeValidator(BaseValidator):
             md5 for md5 in md5s if md5.pii.zip_code in self.zip_codes
         ]
 
+    
+class ExcludeZipCodeValidator(BaseValidator):
+    """
+    Remove leads matching specified zip codes.
+
+    Args:
+        zip_codes: List of zip codes to remove.
+    """
+
+    def __init__(self, zip_codes: list[str]) -> None:
+        """Initialize with a list of zip codes."""
+        self.zip_codes: list[str] = zip_codes
+
+    def _validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
+        """Remove leads that are in the list of zip codes."""
+        return [
+            md5 for md5 in md5s if md5.pii.zip_code not in self.zip_codes
+        ]
+
 
 class ContactableValidator(BaseValidator):
     """Remove leads without a contact method (mobile or email)."""


### PR DESCRIPTION
Builds an `ExcludeZipCodeValidator` as the converse of `ZipCodeValidator`. Test included. 

WTM: allows for exclusively real estate mover leads. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new validator that filters out entries based on specified zip codes, providing an additional way to manage lead inclusion.

- **Tests**
  - Added automated tests to verify that the new exclusion mechanism works correctly by filtering out designated zip code entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->