### PR TITLE
Reduce OpenAI model sizes

### DIFF
--- a/real_intent/analyze/insights/many.py
+++ b/real_intent/analyze/insights/many.py
@@ -82,7 +82,7 @@ class OpenAIInsightsGenerator(BaseAnalyzer):
         @retry_with_backoff()
         def generate_insights():
             return self.openai_client.beta.chat.completions.parse(
-                model="gpt-4o",
+                model="gpt-4o-mini",
                 messages=[
                     {
                         "role": "system",
@@ -258,7 +258,7 @@ class ValidatedInsightsGenerator(BaseAnalyzer):
         @retry_with_backoff()
         def generate_insights():
             return self.openai_client.beta.chat.completions.parse(
-                model="gpt-4o",
+                model="gpt-4o-mini",
                 messages=[
                     {
                         "role": "system",

--- a/real_intent/analyze/insights/per_lead.py
+++ b/real_intent/analyze/insights/per_lead.py
@@ -87,7 +87,7 @@ class PerLeadInsightGenerator(BaseAnalyzer):
         @retry_with_backoff()
         def generate_insight():
             return self.openai_client.beta.chat.completions.parse(
-                model="gpt-4o",
+                model="gpt-4o-mini",
                 messages=[
                     {
                         "role": "system",

--- a/real_intent/deliver/followupboss/ai_fields.py
+++ b/real_intent/deliver/followupboss/ai_fields.py
@@ -273,7 +273,7 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
         # Match the custom fields with the PII data
         log("debug", "Sending request to OpenAI for field mapping")
         response = self.openai_client.chat.completions.create(
-            model="gpt-4o-2024-08-06",
+            model="gpt-4o-mini",
             messages=[
                 {
                     "role": "system",


### PR DESCRIPTION
Closes #203. Reduce model sizes (eventual distillation) to shrink AI inference cost by ~7x for OpenAI-based tasks. Anthropic models are still large, but necessarily so as those tasks require superior intelligence. Perplexity models are not in use by client code.

## Previous LLM Breakdown

### OpenAI Models

1. **GPT-4o**
   - **Where**: `OpenAIInsightsGenerator` in `real_intent/analyze/insights/many.py`
   - **When**: For generating insights from PII data
   - **Why**: To analyze lead data and extract meaningful insights

2. **GPT-4o**
   - **Where**: `ValidatedInsightsGenerator` in `real_intent/analyze/insights/many.py`
   - **When**: For generating validated insights with profile and validation information
   - **Why**: To provide insights that take into account validation rules

3. **GPT-4o**
   - **Where**: `PerLeadInsightGenerator` in `real_intent/analyze/insights/per_lead.py`
   - **When**: For generating insights for individual leads
   - **Why**: To provide personalized insights for each lead

4. **GPT-4o-2024-08-06**
   - **Where**: `AIFollowUpBossDeliverer` in `real_intent/deliver/followupboss/ai_fields.py`
   - **When**: For mapping PII data fields to custom fields in Follow Up Boss CRM
   - **Why**: To intelligently match lead data with the appropriate CRM fields

### Anthropic Models

1. **Claude 3.5 Sonnet (claude-3-5-sonnet-20241022)**
   - **Where**: Scrapybara integration in `real_intent/events/scrapy_claude/__init__.py`
   - **When**: For event generation using web scraping
   - **Why**: To automate web interactions and extract relevant information

2. **Claude 3.7 Sonnet (claude-3-7-sonnet-20250219)**
   - **Where**: SERP event generator in `real_intent/events/serp/__init__.py`
   - **When**: For processing search engine results
   - **Why**: To extract and analyze information from search results

### Perplexity Models

1. **Llama 3.1 Sonar Large 128k (llama-3.1-sonar-large-128k-online)**
   - **Where**: Perplexity API integration in `real_intent/events/perplexity/__init__.py`
   - **When**: For generating content with online search capabilities
   - **Why**: To provide up-to-date information with web search integration

### Summary of Usage Patterns

- **Analysis**: OpenAI models (primarily GPT-4o) are used for analyzing lead data and generating insights
- **CRM Integration**: OpenAI is used for intelligent field mapping in Follow Up Boss
- **Web Scraping**: Claude models are used with Scrapybara for automated web interactions
- **Search Processing**: Claude is used for processing SERP results
- **Online Research**: Llama 3.1 via Perplexity is used for generating content with web search capabilities

## Now

We're opting for `gpt-4o-mini` for top-level insight generation (both naive and validated implementations), per-lead insight generation, and FollowUpBoss AI field mapping. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the AI engine powering insights and suggestions, resulting in more consistent performance when processing personal and lead data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->