### PR TITLE
Improve kvCORE predictive lead type categorization

### DIFF
--- a/real_intent/deliver/kvcore/__init__.py
+++ b/real_intent/deliver/kvcore/__init__.py
@@ -132,11 +132,13 @@ class KVCoreDeliverer(BaseOutputDeliverer):
     def _lead_deal_type(self, pii_md5: MD5WithPII) -> str:
         """Calculated guess if the lead is a buyer or a seller."""
         seller_sentence_matches: set[str] = {
-            "Sellers", "Pre-Movers"
+            "In-Market>Real Estate>Sellers", 
+            "In-Market>Real Estate>Pre-Movers"
         }
 
         buyer_sentence_matches: set[str] = {
-            "Mortgages"
+            "In-Market>Financial>Loans>Mortgages",
+            "In-Market>Real Estate>First-Time Home Buyer"
         }
 
         if any([sentence in seller_sentence_matches for sentence in pii_md5.sentences]):

--- a/tests/test_kvcore.py
+++ b/tests/test_kvcore.py
@@ -18,7 +18,7 @@ def test_kvcore_email_body(sample_pii_md5s) -> None:
     assert "Email" in email_body, "Email should be in email body"
     assert "Phone" in email_body, "Phone should be in email body"
     assert "Agent Notes" in email_body, "Agent Notes should be in email body"
-    
+
     # Verify address components appear in agent notes
     pii = sample_pii_md5s[0].pii
     if pii.address.strip():
@@ -34,34 +34,42 @@ def test_kvcore_email_body(sample_pii_md5s) -> None:
 def test_lead_deal_type() -> None:
     """Test the deal type prediction functionality."""
     deliverer = KVCoreDeliverer("", "", "", "")
-    
+
     # Create test cases for different sentence types
     pii = PII.create_fake(seed=42)
-    
+
     # Test seller detection
     seller_md5 = MD5WithPII(
         md5="seller123",
-        sentences=["Sellers", "Some other sentence"],
+        sentences=["In-Market>Real Estate>Sellers", "Some other sentence"],
         pii=pii
     )
     assert deliverer._lead_deal_type(seller_md5) == "Seller", "Should identify as Seller"
-    
+
     # Test pre-mover detection (also a seller)
     pre_mover_md5 = MD5WithPII(
         md5="premover123",
-        sentences=["Pre-Movers", "Some other sentence"],
+        sentences=["In-Market>Real Estate>Pre-Movers", "Some other sentence"],
         pii=pii
     )
     assert deliverer._lead_deal_type(pre_mover_md5) == "Seller", "Should identify as Seller"
-    
-    # Test buyer detection
-    buyer_md5 = MD5WithPII(
+
+    # Test buyer detection - mortgage
+    buyer_md5_mortgage = MD5WithPII(
         md5="buyer123",
-        sentences=["Mortgages", "Some other sentence"],
+        sentences=["In-Market>Financial>Loans>Mortgages", "Some other sentence"],
         pii=pii
     )
-    assert deliverer._lead_deal_type(buyer_md5) == "Buyer", "Should identify as Buyer"
-    
+    assert deliverer._lead_deal_type(buyer_md5_mortgage) == "Buyer", "Should identify as Buyer"
+
+    # Test buyer detection - first-time home buyer
+    buyer_md5_first_time = MD5WithPII(
+        md5="buyer456",
+        sentences=["In-Market>Real Estate>First-Time Home Buyer", "Some other sentence"],
+        pii=pii
+    )
+    assert deliverer._lead_deal_type(buyer_md5_first_time) == "Buyer", "Should identify as Buyer"
+
     # Test no match
     unknown_md5 = MD5WithPII(
         md5="unknown123",
@@ -74,24 +82,24 @@ def test_lead_deal_type() -> None:
 def test_deal_type_in_email_body() -> None:
     """Test that deal type is included in the email body when it can be determined."""
     deliverer = KVCoreDeliverer("", "", "", "")
-    
+
     # Create a test case with a seller intent
     pii = PII.create_fake(seed=42)
     seller_md5 = MD5WithPII(
         md5="seller123",
-        sentences=["Sellers"],
+        sentences=["In-Market>Real Estate>Sellers"],
         pii=pii
     )
-    
+
     email_body = deliverer._email_body(seller_md5)
     assert "Deal Type: Seller" in email_body, "Deal Type should be in email body for sellers"
-    
+
     # Create a test case with no deal type
     unknown_md5 = MD5WithPII(
         md5="unknown123",
         sentences=["Some random sentence"],
         pii=pii
     )
-    
+
     email_body = deliverer._email_body(unknown_md5)
     assert "Deal Type:" not in email_body, "Deal Type should not be in email body when not determined"


### PR DESCRIPTION
Received feedback indicating most leads were being categorized as buyers within kvCORE post-integration. Adjust the prediction mechanism to match categories in their full forms, and add new relevant categories to widen the prediction net. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in identifying buyers and sellers by using more specific category labels.
- **Tests**
	- Updated tests to reflect the new hierarchical category formats.
	- Added a new test case for first-time home buyers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->