### PR TITLE
Implement ultra high net worth validation spec

### DIFF
--- a/real_intent/validate/pii.py
+++ b/real_intent/validate/pii.py
@@ -151,3 +151,23 @@ class HNWValidator(BaseValidator):
             if md5.pii.household_income in income_levels 
             and md5.pii.household_net_worth in net_worth_levels
         ]
+
+
+class UHNWValidator(BaseValidator):
+    """Remove leads below Ultra High Net Worth (UHNW): $250k+ income and $500k+ net worth."""
+
+    def _validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
+        """Remove leads that do not match the UHNW requirement."""
+        income_levels = {
+            "O. $250K +"
+        }
+        
+        net_worth_levels = {
+            "J. Greater than $499,999"
+        }
+        
+        return [
+            md5 for md5 in md5s 
+            if md5.pii.household_income in income_levels 
+            and md5.pii.household_net_worth in net_worth_levels
+        ]


### PR DESCRIPTION
Introduces a `UHNWValidator` under `real_intent.validate.pii` as a `BaseValidator` type capable of filtering `MD5WithPII` types to only retain profiles with over $250k income and over $499,999 in net worth (the highest possible criterion for each metric). 