### PR TITLE
Improve FUB AI matching prompt and support 50 fields

### DIFF
--- a/real_intent/deliver/followupboss/ai_fields.py
+++ b/real_intent/deliver/followupboss/ai_fields.py
@@ -191,7 +191,11 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
             return self.custom_fields
 
         with log_span("Fetching custom fields from Follow Up Boss", _level="trace"):
-            response = requests.get(f"{self.base_url}/customFields", headers=self.api_headers)
+            response = requests.get(
+                f"{self.base_url}/customFields", 
+                headers=self.api_headers,
+                params={"limit": 50}
+            )
             response.raise_for_status()
             raw_res = response.json()["customfields"]
             custom_fields = [CustomField(**field) for field in raw_res]

--- a/real_intent/deliver/followupboss/ai_prompt.py
+++ b/real_intent/deliver/followupboss/ai_prompt.py
@@ -3,6 +3,8 @@
 SYSTEM_PROMPT = """Your job is to look at PII data and match it to a list of custom fields.
 The custom fields may have different names or formats than the PII data, so your job is to determine if, and only if, an attribute of the PII data matches a custom field. If you are unsure, do not make a match. If you are certain that a PII attribute matches a custom field, make a match.
 
+IMPORTANT: You MUST ONLY use the exact field names provided in the "name" property of each custom field. DO NOT create or invent new field names. If you don't see a custom field that matches a PII attribute, do not include that attribute in your response.
+
 Your response must be JSON only, with string keys and string, integer, boolean, or date values. The keys are the custom field names ("name" key of a custom field dictionary), and the values are the PII data attributes.
 If you're including a date value, use ISO 8601 format (YYYY-MM-DD), ex. "2022-01-01".
 

--- a/real_intent/deliver/followupboss/ai_prompt.py
+++ b/real_intent/deliver/followupboss/ai_prompt.py
@@ -75,7 +75,7 @@ Custom fields:
 
 You should respond with:
 {
-    "customAge": "79",
+    "customAge": 79,
     "customGender": "Male",
     "customNetWorth": "J. Greater than $499,999"
 }


### PR DESCRIPTION
Better structured output prompting for FUB AI field matching, enforcing existence of account fields before suggesting matches. 

When pulling an account's fields, support up to 50 retrieved fields simultaneously without pagination. 

Note: If still seeing many "unmapped field" warning logs in the future, this will need to be re-addressed from another angle. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Limited the number of custom fields fetched from Follow Up Boss to improve performance and reliability.

- **Documentation**
  - Updated AI prompt instructions for more accurate and consistent field name usage and data formatting in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->