### PR TITLE
Upgrade Python patch in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.13.1-bullseye
+FROM python:3.13.3-bullseye
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
To 3.13.3. Next upgrade should be on Tuesday, June 3rd for 3.13.4 in accordance with [PEP 719](https://peps.python.org/pep-0719/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the base Docker image to use a newer Python version (3.13.3).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->