### PR TITLE
Upgrade Python patch to 3.13.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.13.3-bullseye
+FROM python:3.13.5-bullseye
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
From 3.13.3 to 3.13.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base Docker image to use a newer Python version for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->