### PR TITLE
Fix exception variable scope causing `UnboundLocalError`

### DIFF
--- a/real_intent/validate/phone.py
+++ b/real_intent/validate/phone.py
@@ -30,6 +30,9 @@ class PhoneValidator(BaseValidator):
         if len(phone) != 10:
             return False
 
+        if not phone.isdigit():
+            return False
+
         response = requests.get(
             "https://apilayer.net/api/validate",
             params={

--- a/real_intent/validate/phone.py
+++ b/real_intent/validate/phone.py
@@ -89,10 +89,11 @@ class PhoneValidator(BaseValidator):
             try:
                 return self._validate_phone(phone)
             except requests.RequestException as e:
+                phone_request_exc = e
                 time.sleep(random.uniform(3, 5))
 
         log("error", f"All validation attempts failed for phone {phone}")
-        raise e  # re-raise the last exception
+        raise phone_request_exc  # re-raise the last exception
 
     def _validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
         """Remove any phone numbers that are not considered valid."""


### PR DESCRIPTION
The interpreter drops exception variables outside of the try/except scope (i.e. `e` in `except RequestException as e`) so we store it explicitly to reference it later. 

Only causes an issue when for all three retried attempts, specifically a `RequestException` is caught. In that case, instead of re-raising properly, an unexpected `UnboundLocalError` is raised as `e` is no longer in scope. 

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/49596940-3b36-4e67-9b79-10bddd3427cc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for phone validation retries to ensure exceptions are properly captured and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->