### PR TITLE
Align dependencies between pyproject and requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,6 @@ Repository = "https://github.com/Standard-Labs/real-intent.git"
 [project.optional-dependencies]
 logfire = ["logfire>=3.16.2"]
 ai = ["openai>=1.97.0"]
-events = ["scrapybara>=2.0.6", "playwright>=1.49.1", "httpx==0.27.0", "anthropic>=0.49.0", "tldextract>=5.0.0"]
-pdf = ["reportlab>=4.2.5"]
+events = ["scrapybara>=2.3.0", "playwright>=1.49.1", "httpx==0.27.0", "anthropic>=0.49.0", "tldextract>=5.0.0"]
+pdf = ["reportlab>=4.4.2"]
 dns = ["pymongo"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ pydantic>=2.10.4
 pandas
 requests
 
-logfire>=2.11.1
+logfire>=3.16.2
 openai==1.97.0
-reportlab==4.4.2
+reportlab>=4.4.2
 
 python-dotenv
 
-scrapybara==2.3.0
+scrapybara>=2.3.0
 playwright>=1.49.1
 
 httpx==0.27.0
@@ -16,4 +16,4 @@ pymongo
 
 anthropic>=0.49.0
 
-tldextract
+tldextract>=5.0.0


### PR DESCRIPTION
Pin version within requirements similar to pyproject, and align by using the higher version from either in both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated optional dependency minimums to improve compatibility and stability (e.g., events uses scrapybara 2.3.0+; PDF generation uses reportlab 4.4.2+).
  * Relaxed strict version pins to minimum constraints in requirements to reduce conflicts and ease upgrades.
  * Added an explicit minimum version for domain parsing (tldextract 5.0.0+).
  * No changes to features or public APIs; behavior remains the same for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->