### PR TITLE
Revert CI workflow runners to GitHub-hosted

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ on:
   
 jobs:
   test:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
Move away from Depot workers and switch back to GitHub-hosted action runners for `tests` workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->