### PR TITLE
Disable Scrapybara tests within test suite only

### DIFF
--- a/tests/test_events_generator.py
+++ b/tests/test_events_generator.py
@@ -101,6 +101,7 @@ def extract_date_from_range(date_str: str) -> str:
     raise ValueError(f"Could not extract date from: {date_str}")
 
 
+@pytest.mark.skip(reason="Scrapybara not in use anymore")
 def test_beverly_hills_events_scrapybara(scrapybara_events_generator):
     """Test generating events for Beverly Hills (90210) using Scrapybara."""
     try:
@@ -244,6 +245,7 @@ def test_pdf_generation(scrapybara_events_generator, dummy_events_response):
     assert len(pdf_buffer.getvalue()) > 1000, "PDF should have meaningful content"
 
 
+@pytest.mark.skip(reason="Scrapybara not in use anymore")
 def test_invalid_zip_code_scrapybara(scrapybara_events_generator):
     """Test generation with invalid zip code for Scrapybara."""
     # Test non-string zip code
@@ -263,6 +265,7 @@ def test_invalid_zip_code_scrapybara(scrapybara_events_generator):
         scrapybara_events_generator.generate("abcde")
 
 
+@pytest.mark.skip(reason="Scrapybara not in use anymore")
 def test_invalid_api_key_scrapybara():
     """Test initialization with invalid API key for Scrapybara."""
     # Test non-string API key


### PR DESCRIPTION
Deprecate old event components. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled tests for external service integrations to streamline the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->