### PR TITLE
Flexible dynamic exponential backoff of requests

### DIFF
--- a/real_intent/client.py
+++ b/real_intent/client.py
@@ -53,8 +53,8 @@ class BigDBMClient:
             Maximum number of attempts for each request (default: 3).
         """
         # Validate input
-        if max_request_attempts < 1:
-            raise ValueError("max_request_attempts must be at least 1")
+        if not isinstance(max_request_attempts, int) or max_request_attempts < 1:
+            raise ValueError("max_request_attempts must be an int and at least 1")
             
         self.client_id: str = client_id
         self.client_secret: str = client_secret


### PR DESCRIPTION
Instead of a hardcoded double backoff with (7, 13) delay, create a loop-based exponential backoff with a parameter at instantiation `max_request_attempts` defaulting to 3. Each request fail increments in `30 * n_attempt` seconds, more forgiving to target API. 

Unfortunately the double backoff was failing the entire system a few times due to a brittle provider API. This should be much more robust. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-request timeout (default 30s) and configurable max retry attempts (default 3) to improve connection resilience.
  * Implemented automatic retry with backoff for transient failures, including per-attempt reporting and final failure handling.
  * Input validation ensures retry attempts is at least 1.

* **Documentation**
  * Updated initialization docs to describe new parameters and retry behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->