### PR TITLE
Improve client request design for access token update through refresh

### DIFF
--- a/real_intent/client.py
+++ b/real_intent/client.py
@@ -142,8 +142,7 @@ class BigDBMClient:
         with log_span(f"Requesting {request.method} {request.url}", _level="trace"):
             for n_attempt in range(1, self.max_request_attempts+1):
                 try:
-                    response: dict = self.__request(request)
-                    break
+                    return self.__request(request)
                 except RequestException as e:
                     last_exception: RequestException = e
 
@@ -172,9 +171,6 @@ class BigDBMClient:
                     )
                 )
                 raise last_exception
-
-            log("trace", f"Received response: {response}")
-            return response
     
     def get_config_dates(self) -> ConfigDates:
         """Get the configuration dates from /config."""


### PR DESCRIPTION
With the first redesign of the client request system, it was possible that an access token would expire if multiple requests failed as it wasn't being automatically updated while the client was backing off the provider's API.

This redesigns it with a separation of concerns, giving `_request` the retry logic and `__request` only handles access token refresh. `_request` calls `__request` on backoff which updates the token if needed every time. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified request flow and centralized retry/backoff handling for more reliable network requests.
  * Improved logging and diagnostic correlation across retry attempts to make failures easier to trace.
  * Final failures now surface the original error after exhausting retries, providing clearer error visibility for callers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->